### PR TITLE
updated normalize_file_path

### DIFF
--- a/tasks/handlebars_to_static.js
+++ b/tasks/handlebars_to_static.js
@@ -131,7 +131,7 @@ module.exports = function (grunt) {
             // do some checking first since normalizeMultiTaskFiles is not fail safe
             check_file_group(file_group);
             // few possibilities here.
-            if (file_group.src.length > 1 && is_dest_folder(file_group.dest)) {
+            if (file_group.src.length >= 1 && is_dest_folder(file_group.dest)) {
                 //preserve folder structure and substitute extension
                 return file_group.src.map(function (src) {
                     return {


### PR DESCRIPTION
normalize_file_path now works with the examples.

Before if you give src an array with only one string the examples wouldn't run. Now the examples can still run with only one string in the array.